### PR TITLE
fix: update API endpoints to include versioning in job, stage, and task requests MAPCO-9289

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@map-colonies/jobnik-sdk": "^0.2.0",
+        "@map-colonies/jobnik-sdk": "^0.3.0",
         "@map-colonies/tsconfig": "^1.0.1",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/context-async-hooks": "^2.1.0",
@@ -527,9 +527,9 @@
       "license": "MIT"
     },
     "node_modules/@map-colonies/jobnik-sdk": {
-      "version": "0.2.0",
-      "resolved": "file:../jobnik-sdk/map-colonies-jobnik-sdk-0.2.0.tgz",
-      "integrity": "sha512-BP3qnlLNrtvUt5ojMSjxWceX2UZ3E33tyoiQ6HNt+TbvRiSh8E6ZjrXSlvJmi3/hLib2fLTBp1Soyw88aueyNg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@map-colonies/jobnik-sdk/-/jobnik-sdk-0.3.0.tgz",
+      "integrity": "sha512-UrCYafGTE6Gix5S+hQpJjVcPcrSoDGv2Tui334DnvQ9Q/jyGgtSEvNrEwIaEDt0PtPrDjnlBmbIFwu8r8//P5w==",
       "license": "ISC",
       "dependencies": {
         "@map-colonies/read-pkg": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/MapColonies/jobnik-e2e#readme",
   "dependencies": {
-    "@map-colonies/jobnik-sdk": "^0.2.0",
+    "@map-colonies/jobnik-sdk": "^0.3.0",
     "@map-colonies/tsconfig": "^1.0.1",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/context-async-hooks": "^2.1.0",

--- a/tests/abort.spec.ts
+++ b/tests/abort.spec.ts
@@ -41,7 +41,7 @@ describe("Job Abortion Test", () => {
     //#region Start first task to put job in IN_PROGRESS state
     await consumer.dequeueTask(stage.type);
 
-    const jobInProgress = await api.GET("/jobs/{jobId}", {
+    const jobInProgress = await api.GET("/v1/jobs/{jobId}", {
       params: { path: { jobId: job.id } },
     });
 
@@ -51,7 +51,7 @@ describe("Job Abortion Test", () => {
     //#endregion
 
     //#region Abort the job
-    const abortResponse = await api.PUT("/jobs/{jobId}/status", {
+    const abortResponse = await api.PUT("/v1/jobs/{jobId}/status", {
       params: { path: { jobId: job.id } },
       body: { status: "ABORTED" },
     });
@@ -62,7 +62,7 @@ describe("Job Abortion Test", () => {
     //#endregion
 
     //#region Verify job is aborted
-    const abortedJob = await api.GET("/jobs/{jobId}", {
+    const abortedJob = await api.GET("/v1/jobs/{jobId}", {
       params: { path: { jobId: job.id } },
     });
 
@@ -95,7 +95,7 @@ describe("Job Abortion Test", () => {
     expect(dequeuedTask).toHaveProperty("stageId", stage.id);
 
     await consumer.markTaskCompleted(dequeuedTask!.id);
-    const completedJob = await api.GET("/jobs/{jobId}", {
+    const completedJob = await api.GET("/v1/jobs/{jobId}", {
       params: { path: { jobId: job.id } },
     });
 
@@ -103,7 +103,7 @@ describe("Job Abortion Test", () => {
     //#endregion
 
     //#region Try to abort completed job - should succeed (abort is idempotent for terminal states)
-    const abortResponse = await api.PUT("/jobs/{jobId}/status", {
+    const abortResponse = await api.PUT("/v1/jobs/{jobId}/status", {
       params: { path: { jobId: job.id } },
       body: { status: "ABORTED" },
     });

--- a/tests/deleteJob.spec.ts
+++ b/tests/deleteJob.spec.ts
@@ -45,13 +45,13 @@ describe("Delete Job Tests", () => {
     } else if (testName === "failed") {
       await consumer.markTaskFailed(dequeuedTask!.id);
     } else if (testName === "aborted") {
-      await api.PUT("/jobs/{jobId}/status", {
+      await api.PUT("/v1/jobs/{jobId}/status", {
         params: { path: { jobId: job.id } },
         body: { status: "ABORTED" },
       });
     }
 
-    const jobAfterSetup = await api.GET("/jobs/{jobId}", {
+    const jobAfterSetup = await api.GET("/v1/jobs/{jobId}", {
       params: { path: { jobId: job.id } },
     });
 
@@ -59,7 +59,7 @@ describe("Delete Job Tests", () => {
     //#endregion
 
     //#region Delete the job
-    const deleteResponse = await api.DELETE("/jobs/{jobId}", {
+    const deleteResponse = await api.DELETE("/v1/jobs/{jobId}", {
       params: { path: { jobId: job.id } },
     });
 
@@ -70,7 +70,7 @@ describe("Delete Job Tests", () => {
     //#endregion
 
     //#region Verify job is deleted
-    const getDeletedJob = await api.GET("/jobs/{jobId}", {
+    const getDeletedJob = await api.GET("/v1/jobs/{jobId}", {
       params: { path: { jobId: job.id } },
     });
 
@@ -90,7 +90,7 @@ describe("Delete Job Tests", () => {
 
     await producer.createTasks(stage.id, stage.type, [createTaskData()]);
 
-    const pendingJob = await api.GET("/jobs/{jobId}", {
+    const pendingJob = await api.GET("/v1/jobs/{jobId}", {
       params: { path: { jobId: job.id } },
     });
 
@@ -98,7 +98,7 @@ describe("Delete Job Tests", () => {
     //#endregion
 
     //#region Try to delete the pending job
-    const deleteResponse = await api.DELETE("/jobs/{jobId}", {
+    const deleteResponse = await api.DELETE("/v1/jobs/{jobId}", {
       params: { path: { jobId: job.id } },
     });
 
@@ -109,7 +109,7 @@ describe("Delete Job Tests", () => {
     //#endregion
 
     //#region Verify job still exists
-    const stillExistingJob = await api.GET("/jobs/{jobId}", {
+    const stillExistingJob = await api.GET("/v1/jobs/{jobId}", {
       params: { path: { jobId: job.id } },
     });
 
@@ -133,7 +133,7 @@ describe("Delete Job Tests", () => {
 
     await consumer.dequeueTask(stage.type);
 
-    const inProgressJob = await api.GET("/jobs/{jobId}", {
+    const inProgressJob = await api.GET("/v1/jobs/{jobId}", {
       params: { path: { jobId: job.id } },
     });
 
@@ -141,7 +141,7 @@ describe("Delete Job Tests", () => {
     //#endregion
 
     //#region Try to delete the in-progress job
-    const deleteResponse = await api.DELETE("/jobs/{jobId}", {
+    const deleteResponse = await api.DELETE("/v1/jobs/{jobId}", {
       params: { path: { jobId: job.id } },
     });
 
@@ -152,7 +152,7 @@ describe("Delete Job Tests", () => {
     //#endregion
 
     //#region Verify job still exists
-    const stillExistingJob = await api.GET("/jobs/{jobId}", {
+    const stillExistingJob = await api.GET("/v1/jobs/{jobId}", {
       params: { path: { jobId: job.id } },
     });
 
@@ -178,12 +178,12 @@ describe("Delete Job Tests", () => {
     await consumer.dequeueTask(stage.type);
 
     // Pause it
-    await api.PUT("/jobs/{jobId}/status", {
+    await api.PUT("/v1/jobs/{jobId}/status", {
       params: { path: { jobId: job.id } },
       body: { status: "PAUSED" },
     });
 
-    const pausedJob = await api.GET("/jobs/{jobId}", {
+    const pausedJob = await api.GET("/v1/jobs/{jobId}", {
       params: { path: { jobId: job.id } },
     });
 
@@ -191,7 +191,7 @@ describe("Delete Job Tests", () => {
     //#endregion
 
     //#region Try to delete the paused job
-    const deleteResponse = await api.DELETE("/jobs/{jobId}", {
+    const deleteResponse = await api.DELETE("/v1/jobs/{jobId}", {
       params: { path: { jobId: job.id } },
     });
 
@@ -206,7 +206,7 @@ describe("Delete Job Tests", () => {
     //#region Try to delete non-existent job
     const fakeJobId = "00000000-0000-0000-0000-000000000000" as const;
 
-    const deleteResponse = await api.DELETE("/jobs/{jobId}", {
+    const deleteResponse = await api.DELETE("/v1/jobs/{jobId}", {
       // @ts-expect-error - Testing non-existent job
       params: { path: { jobId: fakeJobId } },
     });
@@ -248,7 +248,7 @@ describe("Delete Job Tests", () => {
     //#endregion
 
     //#region Delete the job
-    const deleteResponse = await api.DELETE("/jobs/{jobId}", {
+    const deleteResponse = await api.DELETE("/v1/jobs/{jobId}", {
       params: { path: { jobId: job.id } },
     });
 
@@ -256,13 +256,13 @@ describe("Delete Job Tests", () => {
     //#endregion
 
     //#region Verify stages are deleted
-    const getStage1 = await api.GET("/stages/{stageId}", {
+    const getStage1 = await api.GET("/v1/stages/{stageId}", {
       params: { path: { stageId: stage1.id } },
     });
 
     expect(getStage1.response.status).toBe(404);
 
-    const getStage2 = await api.GET("/stages/{stageId}", {
+    const getStage2 = await api.GET("/v1/stages/{stageId}", {
       params: { path: { stageId: stage2.id } },
     });
 
@@ -270,13 +270,13 @@ describe("Delete Job Tests", () => {
     //#endregion
 
     //#region Verify tasks are deleted
-    const getTask1 = await api.GET("/tasks/{taskId}", {
+    const getTask1 = await api.GET("/v1/tasks/{taskId}", {
       params: { path: { taskId: task1!.id } },
     });
 
     expect(getTask1.response.status).toBe(404);
 
-    const getTask2 = await api.GET("/tasks/{taskId}", {
+    const getTask2 = await api.GET("/v1/tasks/{taskId}", {
       params: { path: { taskId: task2!.id } },
     });
 

--- a/tests/multipleStagesWorkflow.spec.ts
+++ b/tests/multipleStagesWorkflow.spec.ts
@@ -45,17 +45,17 @@ describe("Multiple Stages Workflow Tests", () => {
     //#endregion
 
     //#region Verify initial states - only first stage should be PENDING
-    const initialStage1 = await api.GET("/stages/{stageId}", {
+    const initialStage1 = await api.GET("/v1/stages/{stageId}", {
       params: { path: { stageId: stage1.id } },
     });
     expect(initialStage1.data?.status).toBe("PENDING");
 
-    const initialStage2 = await api.GET("/stages/{stageId}", {
+    const initialStage2 = await api.GET("/v1/stages/{stageId}", {
       params: { path: { stageId: stage2.id } },
     });
     expect(initialStage2.data?.status).toBe("CREATED");
 
-    const initialStage3 = await api.GET("/stages/{stageId}", {
+    const initialStage3 = await api.GET("/v1/stages/{stageId}", {
       params: { path: { stageId: stage3.id } },
     });
     expect(initialStage3.data?.status).toBe("CREATED");
@@ -66,7 +66,7 @@ describe("Multiple Stages Workflow Tests", () => {
 
     await consumer.markTaskCompleted(task1!.id);
 
-    const completedStage1 = await api.GET("/stages/{stageId}", {
+    const completedStage1 = await api.GET("/v1/stages/{stageId}", {
       params: { path: { stageId: stage1.id } },
     });
     expect(completedStage1.data?.status).toBe("COMPLETED");
@@ -74,19 +74,19 @@ describe("Multiple Stages Workflow Tests", () => {
     //#endregion
 
     //#region Verify second stage now available (PENDING)
-    const activatedStage2 = await api.GET("/stages/{stageId}", {
+    const activatedStage2 = await api.GET("/v1/stages/{stageId}", {
       params: { path: { stageId: stage2.id } },
     });
     expect(activatedStage2.data?.status).toBe("PENDING");
 
-    const stillCreatedStage3 = await api.GET("/stages/{stageId}", {
+    const stillCreatedStage3 = await api.GET("/v1/stages/{stageId}", {
       params: { path: { stageId: stage3.id } },
     });
     expect(stillCreatedStage3.data?.status).toBe("CREATED");
     //#endregion
 
     //#region Verify job progress after first stage
-    const jobAfterStage1 = await api.GET("/jobs/{jobId}", {
+    const jobAfterStage1 = await api.GET("/v1/jobs/{jobId}", {
       params: { path: { jobId: job.id } },
     });
     expect(jobAfterStage1.data?.status).toBe("IN_PROGRESS");
@@ -99,21 +99,21 @@ describe("Multiple Stages Workflow Tests", () => {
 
     await consumer.markTaskCompleted(dequeuedTask2!.id);
 
-    const completedStage2 = await api.GET("/stages/{stageId}", {
+    const completedStage2 = await api.GET("/v1/stages/{stageId}", {
       params: { path: { stageId: stage2.id } },
     });
     expect(completedStage2.data?.status).toBe("COMPLETED");
     //#endregion
 
     //#region Verify third stage now available
-    const activatedStage3 = await api.GET("/stages/{stageId}", {
+    const activatedStage3 = await api.GET("/v1/stages/{stageId}", {
       params: { path: { stageId: stage3.id } },
     });
     expect(activatedStage3.data?.status).toBe("PENDING");
     //#endregion
 
     //#region Verify job progress after second stage
-    const jobAfterStage2 = await api.GET("/jobs/{jobId}", {
+    const jobAfterStage2 = await api.GET("/v1/jobs/{jobId}", {
       params: { path: { jobId: job.id } },
     });
     expect(jobAfterStage2.data?.percentage).toBeGreaterThan(
@@ -126,14 +126,14 @@ describe("Multiple Stages Workflow Tests", () => {
     const dequeuedTask3 = await consumer.dequeueTask(stage3.type);
     await consumer.markTaskCompleted(dequeuedTask3!.id);
 
-    const completedStage3 = await api.GET("/stages/{stageId}", {
+    const completedStage3 = await api.GET("/v1/stages/{stageId}", {
       params: { path: { stageId: stage3.id } },
     });
     expect(completedStage3.data?.status).toBe("COMPLETED");
     //#endregion
 
     //#region Verify job completed
-    const completedJob = await api.GET("/jobs/{jobId}", {
+    const completedJob = await api.GET("/v1/jobs/{jobId}", {
       params: { path: { jobId: job.id } },
     });
     expect(completedJob.data?.status).toBe("COMPLETED");
@@ -170,7 +170,7 @@ describe("Multiple Stages Workflow Tests", () => {
       }
 
       // Verify stage is completed
-      const stageStatus = await api.GET("/stages/{stageId}", {
+      const stageStatus = await api.GET("/v1/stages/{stageId}", {
         params: { path: { stageId: stage.id } },
       });
       expect(stageStatus.data?.status).toBe("COMPLETED");
@@ -178,7 +178,7 @@ describe("Multiple Stages Workflow Tests", () => {
     //#endregion
 
     //#region Verify all stages completed in order
-    const allStages = await api.GET("/jobs/{jobId}/stages", {
+    const allStages = await api.GET("/v1/jobs/{jobId}/stages", {
       params: { path: { jobId: job.id } },
     });
 
@@ -190,7 +190,7 @@ describe("Multiple Stages Workflow Tests", () => {
     //#endregion
 
     //#region Verify job completed
-    const completedJob = await api.GET("/jobs/{jobId}", {
+    const completedJob = await api.GET("/v1/jobs/{jobId}", {
       params: { path: { jobId: job.id } },
     });
     expect(completedJob.data?.status).toBe("COMPLETED");
@@ -223,7 +223,7 @@ describe("Multiple Stages Workflow Tests", () => {
     const percentages = [];
 
     // Initial percentage
-    const initial = await api.GET("/jobs/{jobId}", {
+    const initial = await api.GET("/v1/jobs/{jobId}", {
       params: { path: { jobId: job.id } },
     });
     percentages.push(initial.data!.percentage!);
@@ -234,7 +234,7 @@ describe("Multiple Stages Workflow Tests", () => {
 
       await consumer.markTaskCompleted(dequeuedTask!.id);
 
-      const jobStatus = await api.GET("/jobs/{jobId}", {
+      const jobStatus = await api.GET("/v1/jobs/{jobId}", {
         params: { path: { jobId: job.id } },
       });
       percentages.push(jobStatus.data!.percentage!);
@@ -289,7 +289,7 @@ describe("Multiple Stages Workflow Tests", () => {
 
     await consumer.markTaskFailed(task2!.id);
 
-    const failedStage2 = await api.GET("/stages/{stageId}", {
+    const failedStage2 = await api.GET("/v1/stages/{stageId}", {
       params: { path: { stageId: stage2.id } },
     });
 
@@ -297,14 +297,14 @@ describe("Multiple Stages Workflow Tests", () => {
     //#endregion
 
     //#region Verify job is failed
-    const failedJob = await api.GET("/jobs/{jobId}", {
+    const failedJob = await api.GET("/v1/jobs/{jobId}", {
       params: { path: { jobId: job.id } },
     });
     expect(failedJob.data?.status).toBe("FAILED");
     //#endregion
 
     //#region Verify third stage remains in CREATED state
-    const unchangedStage3 = await api.GET("/stages/{stageId}", {
+    const unchangedStage3 = await api.GET("/v1/stages/{stageId}", {
       params: { path: { stageId: stage3.id } },
     });
     // Stage 3 should still be CREATED or WAITING since it never became available
@@ -342,14 +342,14 @@ describe("Multiple Stages Workflow Tests", () => {
 
     await consumer.markTaskCompleted(task1!.id);
 
-    const completedStage1 = await api.GET("/stages/{stageId}", {
+    const completedStage1 = await api.GET("/v1/stages/{stageId}", {
       params: { path: { stageId: stage1.id } },
     });
     expect(completedStage1.data?.status).toBe("COMPLETED");
     //#endregion
 
     //#region Verify second stage is WAITING (not PENDING)
-    const waitingStage2 = await api.GET("/stages/{stageId}", {
+    const waitingStage2 = await api.GET("/v1/stages/{stageId}", {
       params: { path: { stageId: stage2.id } },
     });
     expect(waitingStage2.data?.status).toBe("WAITING");
@@ -361,12 +361,12 @@ describe("Multiple Stages Workflow Tests", () => {
     //#endregion
 
     //#region Manually transition stage to PENDING
-    await api.PUT("/stages/{stageId}/status", {
+    await api.PUT("/v1/stages/{stageId}/status", {
       params: { path: { stageId: stage2.id } },
       body: { status: "PENDING" },
     });
 
-    const pendingStage2 = await api.GET("/stages/{stageId}", {
+    const pendingStage2 = await api.GET("/v1/stages/{stageId}", {
       params: { path: { stageId: stage2.id } },
     });
     expect(pendingStage2.data?.status).toBe("PENDING");
@@ -386,7 +386,7 @@ describe("Multiple Stages Workflow Tests", () => {
     //#endregion
 
     //#region Verify job completed
-    const completedJob = await api.GET("/jobs/{jobId}", {
+    const completedJob = await api.GET("/v1/jobs/{jobId}", {
       params: { path: { jobId: job.id } },
     });
     expect(completedJob.data?.status).toBe("COMPLETED");
@@ -408,7 +408,7 @@ describe("Multiple Stages Workflow Tests", () => {
     //#endregion
 
     //#region Get all stages via endpoint
-    const allStages = await api.GET("/jobs/{jobId}/stages", {
+    const allStages = await api.GET("/v1/jobs/{jobId}/stages", {
       params: { path: { jobId: job.id } },
     });
 

--- a/tests/pause.spec.ts
+++ b/tests/pause.spec.ts
@@ -37,7 +37,7 @@ describe("pause test", () => {
 
     const jobSampleData = createJobData();
     const job = await producer.createJob(jobSampleData);
-    await api.PUT("/jobs/{jobId}/status", {
+    await api.PUT("/v1/jobs/{jobId}/status", {
       body: { status: "PAUSED" },
       params: { path: { jobId: job.id } },
     });
@@ -47,7 +47,7 @@ describe("pause test", () => {
     //#region create stage
     const stageSampleData = createStageData();
     const stage = await producer.createStage(job.id, stageSampleData);
-    await api.PUT("/stages/{stageId}/status", {
+    await api.PUT("/v1/stages/{stageId}/status", {
       body: { status: "PENDING" },
       params: { path: { stageId: stage.id } },
     });
@@ -56,7 +56,7 @@ describe("pause test", () => {
     const task = await producer.createTasks(stage.id, stage.type, [
       taskSampleData,
     ]);
-    await api.PUT("/tasks/{taskId}/status", {
+    await api.PUT("/v1/tasks/{taskId}/status", {
       body: { status: "PENDING" },
       params: { path: { taskId: task[0]!.id } },
     });
@@ -66,7 +66,7 @@ describe("pause test", () => {
     expect(dequeueResult).toBeNull();
 
     //#region unpause job
-    await api.PUT("/jobs/{jobId}/status", {
+    await api.PUT("/v1/jobs/{jobId}/status", {
       body: { status: "PENDING" },
       params: { path: { jobId: job.id } },
     });

--- a/tests/retry.spec.ts
+++ b/tests/retry.spec.ts
@@ -48,7 +48,7 @@ describe("Task Retry Test", () => {
 
       await consumer.markTaskFailed(dequeuedTask!.id);
 
-      const taskAfterFail = await api.GET("/tasks/{taskId}", {
+      const taskAfterFail = await api.GET("/v1/tasks/{taskId}", {
         params: { path: { taskId: task!.id } },
       });
 
@@ -61,7 +61,7 @@ describe("Task Retry Test", () => {
     //#endregion
 
     //#region Verify stage is marked as failed
-    const failedStage = await api.GET("/stages/{stageId}", {
+    const failedStage = await api.GET("/v1/stages/{stageId}", {
       params: { path: { stageId: stage.id } },
     });
 
@@ -80,7 +80,7 @@ describe("Task Retry Test", () => {
     //#endregion
 
     //#region Verify job is marked as failed
-    const failedJob = await api.GET("/jobs/{jobId}", {
+    const failedJob = await api.GET("/v1/jobs/{jobId}", {
       params: { path: { jobId: job.id } },
     });
 
@@ -112,7 +112,7 @@ describe("Task Retry Test", () => {
 
     await consumer.markTaskFailed(dequeuedTask1!.id);
 
-    const retriedTask = await api.GET("/tasks/{taskId}", {
+    const retriedTask = await api.GET("/v1/tasks/{taskId}", {
       params: { path: { taskId: task!.id } },
     });
 
@@ -128,7 +128,7 @@ describe("Task Retry Test", () => {
 
     await consumer.markTaskCompleted(dequeuedTask2!.id);
 
-    const completedTask = await api.GET("/tasks/{taskId}", {
+    const completedTask = await api.GET("/v1/tasks/{taskId}", {
       params: { path: { taskId: task!.id } },
     });
 
@@ -139,7 +139,7 @@ describe("Task Retry Test", () => {
     //#endregion
 
     //#region Verify stage completed
-    const completedStage = await api.GET("/stages/{stageId}", {
+    const completedStage = await api.GET("/v1/stages/{stageId}", {
       params: { path: { stageId: stage.id } },
     });
 
@@ -159,7 +159,7 @@ describe("Task Retry Test", () => {
     //#endregion
 
     //#region Verify job completed
-    const completedJob = await api.GET("/jobs/{jobId}", {
+    const completedJob = await api.GET("/v1/jobs/{jobId}", {
       params: { path: { jobId: job.id } },
     });
 

--- a/tests/simple.spec.ts
+++ b/tests/simple.spec.ts
@@ -77,12 +77,12 @@ describe("simple test", () => {
     //#endregion
 
     //#region assert initial state
-    const firstStageSummary = await api.GET("/stages/{stageId}/summary", {
+    const firstStageSummary = await api.GET("/v1/stages/{stageId}/summary", {
       params: { path: { stageId: firstStage.id } },
     });
     expect(firstStageSummary.data).toMatchObject(expectedInitialSummary);
 
-    const secondStageSummary = await api.GET("/stages/{stageId}/summary", {
+    const secondStageSummary = await api.GET("/v1/stages/{stageId}/summary", {
       params: { path: { stageId: secondStage.id } },
     });
     expect(secondStageSummary.data).toMatchObject(expectedInitialSummary);
@@ -97,7 +97,7 @@ describe("simple test", () => {
 
     //#region assert progress
     // validate that the first task started also progressed the stage
-    const firstStageRunning = await api.GET("/stages/{stageId}", {
+    const firstStageRunning = await api.GET("/v1/stages/{stageId}", {
       params: { path: { stageId: firstStage.id } },
     });
 
@@ -114,7 +114,7 @@ describe("simple test", () => {
       },
     });
 
-    const currentJob = await api.GET("/jobs/{jobId}", {
+    const currentJob = await api.GET("/v1/jobs/{jobId}", {
       params: { path: { jobId: job.id } },
     });
 
@@ -134,7 +134,7 @@ describe("simple test", () => {
     await expect(completeFirstTaskPromise).resolves.not.toThrow();
 
     // validate first task completed also progress of stage and job
-    const firstStageCompleted = await api.GET("/stages/{stageId}", {
+    const firstStageCompleted = await api.GET("/v1/stages/{stageId}", {
       params: { path: { stageId: firstStage.id } },
     });
 
@@ -153,11 +153,11 @@ describe("simple test", () => {
     });
 
     //#region Validate second stage now available for dequeueing - changed to PENDING
-    const secondStageAfterFirstCompleted = await api.GET("/stages/{stageId}", {
+    const secondStageAfterFirstCompleted = await api.GET("/v1/stages/{stageId}", {
       params: { path: { stageId: secondStage.id } },
     });
 
-    const jobAfterFirstStageCompleted = await api.GET("/jobs/{jobId}", {
+    const jobAfterFirstStageCompleted = await api.GET("/v1/jobs/{jobId}", {
       params: { path: { jobId: job.id } },
     });
 
@@ -180,7 +180,7 @@ describe("simple test", () => {
 
     await expect(completeSecondTaskPromise).resolves.not.toThrow();
 
-    const secondStageCompleted = await api.GET("/stages/{stageId}", {
+    const secondStageCompleted = await api.GET("/v1/stages/{stageId}", {
       params: { path: { stageId: secondStage.id } },
     });
 
@@ -198,7 +198,7 @@ describe("simple test", () => {
       },
     });
 
-    const jobCompleted = await api.GET("/jobs/{jobId}", {
+    const jobCompleted = await api.GET("/v1/jobs/{jobId}", {
       params: { path: { jobId: job.id } },
     });
 

--- a/tests/wait.spec.ts
+++ b/tests/wait.spec.ts
@@ -43,7 +43,7 @@ describe("wait test", () => {
     //#region create stage
     const stageSampleData = createStageData();
     const stage = await producer.createStage(job.id, stageSampleData, true);
-    await api.PUT("/stages/{stageId}/status", {
+    await api.PUT("/v1/stages/{stageId}/status", {
       body: { status: "WAITING" },
       params: { path: { stageId: stage.id } },
     });
@@ -52,7 +52,7 @@ describe("wait test", () => {
     const task = await producer.createTasks(stage.id, stage.type, [
       taskSampleData,
     ]);
-    await api.PUT("/tasks/{taskId}/status", {
+    await api.PUT("/v1/tasks/{taskId}/status", {
       body: { status: "PENDING" },
       params: { path: { taskId: task[0]!.id } },
     });
@@ -62,7 +62,7 @@ describe("wait test", () => {
     expect(dequeueResult).toBeNull();
 
     //#region unwait stage
-    await api.PUT("/stages/{stageId}/status", {
+    await api.PUT("/v1/stages/{stageId}/status", {
       body: { status: "PENDING" },
       params: { path: { stageId: stage.id } },
     });


### PR DESCRIPTION
Introduce versioning in the API endpoints for job, stage, and task requests to ensure consistency and clarity in API usage.

